### PR TITLE
Remove irritating println! from test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,6 @@ mod tests {
         for p in pairs {
             let (s, expected_error) = p;
             let dec_result = s.parse::<Bech32>();
-            println!("{:?}", s.to_string());
             if dec_result.is_ok() {
                 println!("{:?}", dec_result.unwrap());
                 panic!("Should be invalid: {:?}", s);


### PR DESCRIPTION
The output of the `invalid` test is quite annoying and distracting. I don't think it adds much value as long as the test succeeds. So I propose to remove the `println!` from the happy path.