### PR TITLE
Derive Clone and Copy trait for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ const CHARSET_REV: [i8; 128] = [
 const GEN: [u32; 5] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
 
 /// Error types for Bech32 encoding / decoding
-#[derive(PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Error {
     /// String does not contain the separator character
     MissingSeparator,


### PR DESCRIPTION
Otherwise every other error type encapsulating `Error` will not be able to derive `Clone` and `Copy`.