### PR TITLE
Release tracking PR: `v0.12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.12.0 - 2024-10-27
+
+This release adds error correction.
+
+- Make `Hrp::len` function const [#212](https://github.com/rust-bitcoin/rust-bech32/pull/212)
+- Remove unused argument on `CheckedHrpstring::fe32_iter` [#235](https://github.com/rust-bitcoin/rust-bech32/pull/235)
+- Fix min/max size hint in `HrpFe32Iter` [#253](https://github.com/rust-bitcoin/rust-bech32/pull/253)
+- Add support for error correction [#203](https://github.com/rust-bitcoin/rust-bech32/pull/203) [#204](https://github.com/rust-bitcoin/rust-bech32/pull/204) [#205](https://github.com/rust-bitcoin/rust-bech32/pull/205)
+- Alternative `fes_to_bytes_zeropad` with no dropping of last bits [#201](https://github.com/rust-bitcoin/rust-bech32/pull/)
+- Derive `Default` for `Fe32` [#184](https://github.com/rust-bitcoin/rust-bech32/pull/184/)
+- Introduce a `PrintImpl` object that can compute various code properties [#180](https://github.com/rust-bitcoin/rust-bech32/pull/180)
+- Add a `Hrp` constructor from an arbitrary `T: Display` [#196](https://github.com/rust-bitcoin/rust-bech32/pull/196)
+
 # 0.11.0 - 2024-02-23
 
 The `0.10.0` release contains API breaking changes compared to `0.10.0-beta` and because of semver

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.12.0"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bech32"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Clark Moody", "Andrew Poelstra", "Tobin Harding"]
 repository = "https://github.com/rust-bitcoin/rust-bech32"
 documentation = "https://docs.rs/bech32/"


### PR DESCRIPTION
In preparation for release add a changelog entry and bump the version.
