### PR TITLE
Run the linter

### DIFF
--- a/src/primitives/correction.rs
+++ b/src/primitives/correction.rs
@@ -175,7 +175,7 @@ impl<Ck: Checksum> Corrector<Ck> {
     ///
     /// If the input string has sufficiently many errors, this unique closest correct
     /// string may not actually be the intended string.
-    pub fn bch_errors(&self) -> Option<ErrorIterator<Ck>> {
+    pub fn bch_errors(&self) -> Option<ErrorIterator<'_, Ck>> {
         // 1. Compute all syndromes by evaluating the residue at each power of the generator.
         let syndromes: Polynomial<_> = Ck::ROOT_GENERATOR
             .powers_range(Ck::ROOT_EXPONENTS)

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -444,7 +444,7 @@ impl<'s> CheckedHrpstring<'s> {
     ///
     /// Converts the ASCII bytes representing field elements to the respective field elements.
     #[inline]
-    pub fn fe32_iter(&self, _: u8) -> AsciiToFe32Iter {
+    pub fn fe32_iter(&self, _: u8) -> AsciiToFe32Iter<'_> {
         AsciiToFe32Iter { iter: self.ascii.iter().copied() }
     }
 
@@ -453,7 +453,7 @@ impl<'s> CheckedHrpstring<'s> {
     /// Converts the ASCII bytes representing field elements to the respective field elements, then
     /// converts the stream of field elements to a stream of bytes.
     #[inline]
-    pub fn byte_iter(&self) -> ByteIter {
+    pub fn byte_iter(&self) -> ByteIter<'_> {
         ByteIter { iter: AsciiToFe32Iter { iter: self.ascii.iter().copied() }.fes_to_bytes() }
     }
 
@@ -663,7 +663,7 @@ impl<'s> SegwitHrpstring<'s> {
     ///
     /// Use `self.witness_version()` to get the witness version.
     #[inline]
-    pub fn byte_iter(&self) -> ByteIter {
+    pub fn byte_iter(&self) -> ByteIter<'_> {
         ByteIter { iter: AsciiToFe32Iter { iter: self.ascii.iter().copied() }.fes_to_bytes() }
     }
 }

--- a/src/primitives/fieldvec.rs
+++ b/src/primitives/fieldvec.rs
@@ -129,7 +129,7 @@ impl<F> FieldVec<F> {
     /// # Panics
     ///
     /// Panics if [`Self::has_data`] is false.
-    pub fn iter(&self) -> slice::Iter<F> {
+    pub fn iter(&self) -> slice::Iter<'_, F> {
         if self.len > NO_ALLOC_MAX_LENGTH {
             self.assert_has_data();
             #[cfg(feature = "alloc")]
@@ -143,7 +143,7 @@ impl<F> FieldVec<F> {
     /// # Panics
     ///
     /// Panics if [`Self::has_data`] is false.
-    pub fn iter_mut(&mut self) -> slice::IterMut<F> {
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, F> {
         if self.len > NO_ALLOC_MAX_LENGTH {
             self.assert_has_data();
             #[cfg(feature = "alloc")]

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -237,24 +237,24 @@ impl Hrp {
     /// If an uppercase HRP was parsed during object construction then this iterator will yield
     /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_byte_iter`]
     #[inline]
-    pub fn byte_iter(&self) -> ByteIter { ByteIter { iter: self.buf[..self.size].iter() } }
+    pub fn byte_iter(&self) -> ByteIter<'_> { ByteIter { iter: self.buf[..self.size].iter() } }
 
     /// Creates a character iterator over the ASCII characters of this HRP.
     ///
     /// If an uppercase HRP was parsed during object construction then this iterator will yield
     /// uppercase ASCII `char`s. For lowercase bytes see [`Self::lowercase_char_iter`].
     #[inline]
-    pub fn char_iter(&self) -> CharIter { CharIter { iter: self.byte_iter() } }
+    pub fn char_iter(&self) -> CharIter<'_> { CharIter { iter: self.byte_iter() } }
 
     /// Creates a lowercase iterator over the byte values (ASCII characters) of this HRP.
     #[inline]
-    pub fn lowercase_byte_iter(&self) -> LowercaseByteIter {
+    pub fn lowercase_byte_iter(&self) -> LowercaseByteIter<'_> {
         LowercaseByteIter { iter: self.byte_iter() }
     }
 
     /// Creates a lowercase character iterator over the ASCII characters of this HRP.
     #[inline]
-    pub fn lowercase_char_iter(&self) -> LowercaseCharIter {
+    pub fn lowercase_char_iter(&self) -> LowercaseCharIter<'_> {
         LowercaseCharIter { iter: self.lowercase_byte_iter() }
     }
 

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -85,7 +85,9 @@ pub trait Fe32IterExt: Sized + Iterator<Item = Fe32> {
 
     /// Adapts the Fe32 iterator to encode the field elements into a bech32 address.
     #[inline]
-    fn with_checksum<Ck: Checksum>(self, hrp: &Hrp) -> Encoder<Self, Ck> { Encoder::new(self, hrp) }
+    fn with_checksum<Ck: Checksum>(self, hrp: &Hrp) -> Encoder<'_, Self, Ck> {
+        Encoder::new(self, hrp)
+    }
 }
 
 impl<I> Fe32IterExt for I where I: Iterator<Item = Fe32> {}

--- a/src/primitives/polynomial.rs
+++ b/src/primitives/polynomial.rs
@@ -73,7 +73,7 @@ impl<F: Field> Polynomial<F> {
     /// # Panics
     ///
     /// Panics if [`Self::has_data`] is false.
-    pub fn iter(&self) -> slice::Iter<F> {
+    pub fn iter(&self) -> slice::Iter<'_, F> {
         self.assert_has_data();
         self.coefficients().iter()
     }


### PR DESCRIPTION
Clippy emits a bunch of warnings of form:

 lifetime flowing from input to output with different syntax can be confusing

Fix them as suggested by using the anonymous lifetime.