### PR TITLE
primitives: fix min/max size hint in HrpFe32Iter

### DIFF
--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -502,8 +502,8 @@ impl Iterator for HrpFe32Iter<'_> {
             None => (0, Some(0)),
         };
 
-        let min = high.0 + 1 + low.0;
-        let max = high.1.zip(low.1).map(|(high, low)| high + 1 + low);
+        let min = high.0 + low.0;
+        let max = high.1.zip(low.1).map(|(high, low)| high + low);
 
         (min, max)
     }
@@ -598,6 +598,19 @@ mod tests {
         .to_string();
         #[cfg(feature = "std")]
         println!("{}", _s);
+    }
+
+    #[test]
+    fn hrp_fe32_iter_size_hint_matches_remaining_length() {
+        let hrp = Hrp::parse_unchecked("ab");
+        let mut iter = HrpFe32Iter::new(&hrp);
+
+        for remaining in (0..=(2 * hrp.len() + 1)).rev() {
+            assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+            if remaining > 0 {
+                iter.next().expect("iterator has more elements");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
While running mutation tests, I noticed a defect.

`HrpFe32Iter` models the BIP 173 HRP expansion used for checksum input.

In [BIP 173](https://en.bitcoin.it/wiki/BIP_0173), HRP expansion is: `[ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]`

In `size_hint()`, the high branch already includes that single inserted separator element. Adding another +1 in the final sum overcounts the remaining length by one.

This patch removes the extra +1 from the final min and max calculations and adds a test asserting that `size_hint()` matches the exact remaining length as the iterator is drained.

This change only corrects iterator length accounting. It does not change the yielded sequence of field elements or checksum semantics.