### PR TITLE
ci: fix nightly cronjob to set environment variables properly

### DIFF
--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         run: cargo install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev $(cat rbmt-version) cargo-rbmt
       - name: Update nightly toolchain in Cargo.toml
         run: |
-          cargo rbmt toolchains --update-nightly
+          eval $(cargo rbmt toolchains --update-nightly)
           echo "nightly_version=$RBMT_NIGHTLY" >> $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8


### PR DESCRIPTION
We were not evaluating the output of `cargo-rbmt` because I was being dumb when we introduced the cronjob. As a result, our weekly rustc update PRs have bad titles and commit descriptions.