### PR TITLE
CI: Use eval in cron job

### DIFF
--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         run: cargo install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev $(cat rbmt-version) cargo-rbmt
       - name: Update nightly toolchain in Cargo.toml
         run: |
-          cargo rbmt toolchains --update-nightly
+          eval $(cargo rbmt toolchains --update-nightly)
           echo "nightly_version=$RBMT_NIGHTLY" >> $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8


### PR DESCRIPTION
We accidentally dropped the usage of `eval` which makes the PR title created by the bot incorrect because the return value of the update command is dropped - oops.