### PR TITLE
Update to rustc nightly-2026-05-15 with lint fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rust-version = "1.56.1"
 
 [package.metadata.rbmt.toolchains]
-nightly = "nightly-2026-05-08"
+nightly = "nightly-2026-05-15"
 stable = "stable"
 
 [features]

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -495,7 +495,7 @@ impl<'s> CheckedHrpstring<'s> {
         let padding_len = fe_iter.len() * 5 % 8;
 
         if padding_len > 4 {
-            return Err(PaddingError::TooMuch)?;
+            return Err(PaddingError::TooMuch);
         }
 
         let last_fe = fe_iter.last().expect("checked above");


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bech32/pull/265

Daily update to Cargo.toml workspace metadata removing an empty return statement, which was being flagged by the linter.
