### PR TITLE
Manual update to rustc to nightly-2026-05-22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rust-version = "1.56.1"
 
 [package.metadata.rbmt.toolchains]
-nightly = "nightly-2026-05-15"
+nightly = "nightly-2026-05-22"
 stable = "stable"
 
 [features]


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bech32/pull/267.

Update to `Cargo.toml` workspace metadata, superseding previous PR to include a rebased fix already present in master.
