### PR TITLE
Fix Pedantic Clippy Lints

### DIFF
--- a/fuzz/fuzz_targets/correct_bech32.rs
+++ b/fuzz/fuzz_targets/correct_bech32.rs
@@ -25,10 +25,7 @@ fn do_test(data: &[u8]) {
         if idx >= CORRECT.len() - 3 {
             return;
         }
-        let offs = match Fe32::try_from(sl[1]) {
-            Ok(fe) => fe,
-            Err(_) => return,
-        };
+        let Ok(offs) = Fe32::try_from(sl[1]) else { return };
 
         hrpstring[idx + 3] =
             (Fe32::from_char(hrpstring[idx + 3].into()).unwrap() + offs).to_char() as u8;

--- a/fuzz/fuzz_targets/correct_codex32.rs
+++ b/fuzz/fuzz_targets/correct_codex32.rs
@@ -50,10 +50,7 @@ fn do_test(data: &[u8]) {
         if idx >= CORRECT.len() - 3 {
             return;
         }
-        let offs = match Fe32::try_from(sl[1]) {
-            Ok(fe) => fe,
-            Err(_) => return,
-        };
+        let Ok(offs) = Fe32::try_from(sl[1]) else { return };
 
         hrpstring[idx + 3] =
             (Fe32::from_char(hrpstring[idx + 3].into()).unwrap() + offs).to_char() as u8;

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -16,18 +16,9 @@ fn do_test(data: &[u8]) {
 
     let dp = &data[hrp_end..];
 
-    let s = match str::from_utf8(&data[1..hrp_end]) {
-        Ok(s) => s,
-        Err(_) => return,
-    };
-    let hrp = match Hrp::parse(s) {
-        Ok(hrp) => hrp,
-        Err(_) => return,
-    };
-    let address = match bech32::encode::<Bech32m>(hrp, dp) {
-        Ok(addr) => addr,
-        Err(_) => return,
-    };
+    let Ok(s) = str::from_utf8(&data[1..hrp_end]) else { return };
+    let Ok(hrp) = Hrp::parse(s) else { return };
+    let Ok(address) = bech32::encode::<Bech32m>(hrp, dp) else { return };
 
     let (hrp, data) = bech32::decode(&address).expect("should be able to decode own encoding");
     assert_eq!(bech32::encode::<Bech32m>(hrp, &data).unwrap(), address);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,11 +467,9 @@ pub enum DecodeError {
 #[cfg(feature = "alloc")]
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use DecodeError::*;
-
         match *self {
-            Parse(ref e) => write_err!(f, "parsing failed"; e),
-            Checksum(ref e) => write_err!(f, "no valid bech32 or bech32m checksum"; e),
+            Self::Parse(ref e) => write_err!(f, "parsing failed"; e),
+            Self::Checksum(ref e) => write_err!(f, "no valid bech32 or bech32m checksum"; e),
         }
     }
 }
@@ -479,11 +477,9 @@ impl fmt::Display for DecodeError {
 #[cfg(feature = "std")]
 impl std::error::Error for DecodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use DecodeError::*;
-
         match *self {
-            Parse(ref e) => Some(e),
-            Checksum(ref e) => Some(e),
+            Self::Parse(ref e) => Some(e),
+            Self::Checksum(ref e) => Some(e),
         }
     }
 }
@@ -512,11 +508,9 @@ pub enum EncodeError {
 
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use EncodeError::*;
-
         match *self {
-            TooLong(ref e) => write_err!(f, "encode error"; e),
-            Fmt(ref e) => write_err!(f, "encode to formatter failed"; e),
+            Self::TooLong(ref e) => write_err!(f, "encode error"; e),
+            Self::Fmt(ref e) => write_err!(f, "encode to formatter failed"; e),
         }
     }
 }
@@ -524,11 +518,9 @@ impl fmt::Display for EncodeError {
 #[cfg(feature = "std")]
 impl std::error::Error for EncodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use EncodeError::*;
-
         match *self {
-            TooLong(ref e) => Some(e),
-            Fmt(ref e) => Some(e),
+            Self::TooLong(ref e) => Some(e),
+            Self::Fmt(ref e) => Some(e),
         }
     }
 }
@@ -557,11 +549,9 @@ pub enum EncodeIoError {
 #[cfg(feature = "std")]
 impl fmt::Display for EncodeIoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use EncodeIoError::*;
-
         match *self {
-            TooLong(ref e) => write_err!(f, "encode error"; e),
-            Write(ref e) => write_err!(f, "encode to writer failed"; e),
+            Self::TooLong(ref e) => write_err!(f, "encode error"; e),
+            Self::Write(ref e) => write_err!(f, "encode to writer failed"; e),
         }
     }
 }
@@ -569,11 +559,9 @@ impl fmt::Display for EncodeIoError {
 #[cfg(feature = "std")]
 impl std::error::Error for EncodeIoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use EncodeIoError::*;
-
         match *self {
-            TooLong(ref e) => Some(e),
-            Write(ref e) => Some(e),
+            Self::TooLong(ref e) => Some(e),
+            Self::Write(ref e) => Some(e),
         }
     }
 }

--- a/src/primitives/checksum.rs
+++ b/src/primitives/checksum.rs
@@ -297,7 +297,7 @@ impl<Ck: Checksum> Default for Engine<Ck> {
 impl<Ck: Checksum> Engine<Ck> {
     /// Constructs a new checksum engine with no data input.
     #[inline]
-    pub fn new() -> Self { Engine { residue: Ck::MidstateRepr::ONE } }
+    pub fn new() -> Self { Self { residue: Ck::MidstateRepr::ONE } }
 
     /// Feeds `hrp` into the checksum engine.
     #[inline]
@@ -381,14 +381,14 @@ pub trait PackedFe32: Copy + PartialEq + Eq + ops::BitXor<Self, Output = Self> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PackedNull;
 
-impl ops::BitXor<PackedNull> for PackedNull {
-    type Output = PackedNull;
+impl ops::BitXor<Self> for PackedNull {
+    type Output = Self;
     #[inline]
-    fn bitxor(self, _: PackedNull) -> PackedNull { PackedNull }
+    fn bitxor(self, _: Self) -> Self { Self }
 }
 
 impl PackedFe32 for PackedNull {
-    const ONE: Self = PackedNull;
+    const ONE: Self = Self;
     #[inline]
     fn unpack(&self, _: usize) -> u8 { 0 }
     #[inline]

--- a/src/primitives/correction.rs
+++ b/src/primitives/correction.rs
@@ -91,7 +91,7 @@ impl CorrectableError for InvalidResidueError {
 impl CorrectableError for ChecksumError {
     fn residue_error(&self) -> Option<&InvalidResidueError> {
         match self {
-            ChecksumError::InvalidResidue(ref e) => Some(e),
+            Self::InvalidResidue(ref e) => Some(e),
             _ => None,
         }
     }
@@ -100,7 +100,7 @@ impl CorrectableError for ChecksumError {
 impl CorrectableError for SegwitHrpstringError {
     fn residue_error(&self) -> Option<&InvalidResidueError> {
         match self {
-            SegwitHrpstringError::Checksum(ref e) => e.residue_error(),
+            Self::Checksum(ref e) => e.residue_error(),
             _ => None,
         }
     }
@@ -109,7 +109,7 @@ impl CorrectableError for SegwitHrpstringError {
 impl CorrectableError for CheckedHrpstringError {
     fn residue_error(&self) -> Option<&InvalidResidueError> {
         match self {
-            CheckedHrpstringError::Checksum(ref e) => e.residue_error(),
+            Self::Checksum(ref e) => e.residue_error(),
             _ => None,
         }
     }
@@ -124,7 +124,7 @@ impl CorrectableError for crate::segwit::DecodeError {
 impl CorrectableError for DecodeError {
     fn residue_error(&self) -> Option<&InvalidResidueError> {
         match self {
-            DecodeError::Checksum(ref e) => e.residue_error(),
+            Self::Checksum(ref e) => e.residue_error(),
             _ => None,
         }
     }

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -245,8 +245,6 @@ impl<'s> UncheckedHrpstring<'s> {
     /// checksum if `NoChecksum` is used).
     #[inline]
     pub fn validate_checksum<Ck: Checksum>(&self) -> Result<(), ChecksumError> {
-        use ChecksumError::*;
-
         if self.hrpstring_length > Ck::CODE_LENGTH {
             return Err(ChecksumError::CodeLength(CodeLengthError {
                 encoded_length: self.hrpstring_length,
@@ -260,7 +258,7 @@ impl<'s> UncheckedHrpstring<'s> {
         }
 
         if self.data_part_ascii.len() < Ck::CHECKSUM_LENGTH {
-            return Err(InvalidLength);
+            return Err(ChecksumError::InvalidLength);
         }
 
         let mut checksum_eng = checksum::Engine::<Ck>::new();
@@ -273,7 +271,10 @@ impl<'s> UncheckedHrpstring<'s> {
 
         let residue = *checksum_eng.residue();
         if residue != Ck::TARGET_RESIDUE {
-            return Err(InvalidResidue(InvalidResidueError::new(residue, Ck::TARGET_RESIDUE)));
+            return Err(ChecksumError::InvalidResidue(InvalidResidueError::new(
+                residue,
+                Ck::TARGET_RESIDUE,
+            )));
         }
 
         Ok(())
@@ -661,8 +662,6 @@ impl<'s> SegwitHrpstring<'s> {
 ///
 /// The byte-index into the string where the '1' separator occurs, or an error if it does not.
 fn check_characters(s: &str) -> Result<usize, CharError> {
-    use CharError::*;
-
     let mut has_upper = false;
     let mut has_lower = false;
     let mut req_bech32 = true;
@@ -673,7 +672,7 @@ fn check_characters(s: &str) -> Result<usize, CharError> {
             sep_pos = Some(n);
         }
         if req_bech32 {
-            Fe32::from_char(ch).map_err(|_| InvalidChar(ch))?;
+            Fe32::from_char(ch).map_err(|_| CharError::InvalidChar(ch))?;
         }
         if ch.is_ascii_uppercase() {
             has_upper = true;
@@ -682,11 +681,11 @@ fn check_characters(s: &str) -> Result<usize, CharError> {
         }
     }
     if has_upper && has_lower {
-        Err(MixedCase)
+        Err(CharError::MixedCase)
     } else if let Some(pos) = sep_pos {
         Ok(pos)
     } else {
-        Err(MissingSeparator)
+        Err(CharError::MissingSeparator)
     }
 }
 
@@ -758,18 +757,16 @@ pub enum SegwitHrpstringError {
 #[rustfmt::skip]
 impl fmt::Display for SegwitHrpstringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use SegwitHrpstringError::*;
-
         match *self {
-            Unchecked(ref e) => write_err!(f, "parsing unchecked hrpstring failed"; e),
-            NoData => write!(f, "no data found after removing the checksum"),
-            TooLong(len) =>
+            Self::Unchecked(ref e) => write_err!(f, "parsing unchecked hrpstring failed"; e),
+            Self::NoData => write!(f, "no data found after removing the checksum"),
+            Self::TooLong(len) =>
                 write!(f, "encoded length {} exceeds spec limit {} chars", len, segwit::MAX_STRING_LENGTH),
-            InvalidWitnessVersion(fe) =>
+            Self::InvalidWitnessVersion(fe) =>
                 write!(f, "invalid segwit witness version: {} (bech32 character: '{}')", fe.to_u8(), fe),
-            Padding(ref e) => write_err!(f, "invalid padding on the witness data"; e),
-            WitnessLength(ref e) => write_err!(f, "invalid witness length"; e),
-            Checksum(ref e) => write_err!(f, "invalid checksum"; e),
+            Self::Padding(ref e) => write_err!(f, "invalid padding on the witness data"; e),
+            Self::WitnessLength(ref e) => write_err!(f, "invalid witness length"; e),
+            Self::Checksum(ref e) => write_err!(f, "invalid checksum"; e),
         }
     }
 }
@@ -777,14 +774,12 @@ impl fmt::Display for SegwitHrpstringError {
 #[cfg(feature = "std")]
 impl std::error::Error for SegwitHrpstringError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use SegwitHrpstringError::*;
-
         match *self {
-            Unchecked(ref e) => Some(e),
-            Padding(ref e) => Some(e),
-            WitnessLength(ref e) => Some(e),
-            Checksum(ref e) => Some(e),
-            NoData | TooLong(_) | InvalidWitnessVersion(_) => None,
+            Self::Unchecked(ref e) => Some(e),
+            Self::Padding(ref e) => Some(e),
+            Self::WitnessLength(ref e) => Some(e),
+            Self::Checksum(ref e) => Some(e),
+            Self::NoData | Self::TooLong(_) | Self::InvalidWitnessVersion(_) => None,
         }
     }
 }
@@ -821,11 +816,9 @@ pub enum CheckedHrpstringError {
 
 impl fmt::Display for CheckedHrpstringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use CheckedHrpstringError::*;
-
         match *self {
-            Parse(ref e) => write_err!(f, "parse failed"; e),
-            Checksum(ref e) => write_err!(f, "invalid checksum"; e),
+            Self::Parse(ref e) => write_err!(f, "parse failed"; e),
+            Self::Checksum(ref e) => write_err!(f, "invalid checksum"; e),
         }
     }
 }
@@ -833,11 +826,9 @@ impl fmt::Display for CheckedHrpstringError {
 #[cfg(feature = "std")]
 impl std::error::Error for CheckedHrpstringError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use CheckedHrpstringError::*;
-
         match *self {
-            Parse(ref e) => Some(e),
-            Checksum(ref e) => Some(e),
+            Self::Parse(ref e) => Some(e),
+            Self::Checksum(ref e) => Some(e),
         }
     }
 }
@@ -864,11 +855,9 @@ pub enum UncheckedHrpstringError {
 
 impl fmt::Display for UncheckedHrpstringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use UncheckedHrpstringError::*;
-
         match *self {
-            Char(ref e) => write_err!(f, "character error"; e),
-            Hrp(ref e) => write_err!(f, "invalid human-readable part"; e),
+            Self::Char(ref e) => write_err!(f, "character error"; e),
+            Self::Hrp(ref e) => write_err!(f, "invalid human-readable part"; e),
         }
     }
 }
@@ -876,11 +865,9 @@ impl fmt::Display for UncheckedHrpstringError {
 #[cfg(feature = "std")]
 impl std::error::Error for UncheckedHrpstringError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use UncheckedHrpstringError::*;
-
         match *self {
-            Char(ref e) => Some(e),
-            Hrp(ref e) => Some(e),
+            Self::Char(ref e) => Some(e),
+            Self::Hrp(ref e) => Some(e),
         }
     }
 }
@@ -911,13 +898,13 @@ pub enum CharError {
 
 impl fmt::Display for CharError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use CharError::*;
-
         match *self {
-            MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
-            NothingAfterSeparator => write!(f, "invalid data - no characters after the separator"),
-            InvalidChar(n) => write!(f, "invalid character (code={})", n),
-            MixedCase => write!(f, "mixed-case strings not allowed"),
+            Self::MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
+            Self::NothingAfterSeparator => {
+                write!(f, "invalid data - no characters after the separator")
+            }
+            Self::InvalidChar(n) => write!(f, "invalid character (code={})", n),
+            Self::MixedCase => write!(f, "mixed-case strings not allowed"),
         }
     }
 }
@@ -925,10 +912,11 @@ impl fmt::Display for CharError {
 #[cfg(feature = "std")]
 impl std::error::Error for CharError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use CharError::*;
-
         match *self {
-            MissingSeparator | NothingAfterSeparator | InvalidChar(_) | MixedCase => None,
+            Self::MissingSeparator
+            | Self::NothingAfterSeparator
+            | Self::InvalidChar(_)
+            | Self::MixedCase => None,
         }
     }
 }
@@ -947,12 +935,10 @@ pub enum ChecksumError {
 
 impl fmt::Display for ChecksumError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use ChecksumError::*;
-
         match *self {
-            CodeLength(ref e) => write_err!(f, "string exceeds maximum allowed length"; e),
-            InvalidResidue(ref e) => write_err!(f, "checksum failed"; e),
-            InvalidLength => write!(f, "the checksummed string is not a valid length"),
+            Self::CodeLength(ref e) => write_err!(f, "string exceeds maximum allowed length"; e),
+            Self::InvalidResidue(ref e) => write_err!(f, "checksum failed"; e),
+            Self::InvalidLength => write!(f, "the checksummed string is not a valid length"),
         }
     }
 }
@@ -960,12 +946,10 @@ impl fmt::Display for ChecksumError {
 #[cfg(feature = "std")]
 impl std::error::Error for ChecksumError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use ChecksumError::*;
-
         match *self {
-            CodeLength(ref e) => Some(e),
-            InvalidResidue(ref e) => Some(e),
-            InvalidLength => None,
+            Self::CodeLength(ref e) => Some(e),
+            Self::InvalidResidue(ref e) => Some(e),
+            Self::InvalidLength => None,
         }
     }
 }
@@ -1087,11 +1071,9 @@ pub enum PaddingError {
 
 impl fmt::Display for PaddingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use PaddingError::*;
-
         match *self {
-            TooMuch => write!(f, "the data payload has too many bits of padding"),
-            NonZero => write!(f, "the data payload is padded with non-zero bits"),
+            Self::TooMuch => write!(f, "the data payload has too many bits of padding"),
+            Self::NonZero => write!(f, "the data payload is padded with non-zero bits"),
         }
     }
 }
@@ -1099,10 +1081,8 @@ impl fmt::Display for PaddingError {
 #[cfg(feature = "std")]
 impl std::error::Error for PaddingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use PaddingError::*;
-
         match *self {
-            TooMuch | NonZero => None,
+            Self::TooMuch | Self::NonZero => None,
         }
     }
 }

--- a/src/primitives/fieldvec.rs
+++ b/src/primitives/fieldvec.rs
@@ -210,7 +210,7 @@ impl<F: Default> Default for FieldVec<F> {
 impl<F: Default> FieldVec<F> {
     /// Constructs a new empty field vector.
     pub fn new() -> Self {
-        FieldVec {
+        Self {
             inner_a: Default::default(),
             len: 0,
             #[cfg(feature = "alloc")]

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -183,14 +183,12 @@ impl Fe32 {
     /// If the input char is not part of the bech32 alphabet.
     #[inline]
     pub fn from_char(c: char) -> Result<Self, FromCharError> {
-        use FromCharError::*;
-
         // i8::try_from gets a value in the range 0..=127 since char is unsigned.
-        let byte = i8::try_from(u32::from(c)).map_err(|_| NotAscii(c))?;
+        let byte = i8::try_from(u32::from(c)).map_err(|_| FromCharError::NotAscii(c))?;
         // Now we have a valid ASCII value cast is safe.
         let ascii = byte as usize;
         // We use -1 for any array element that is an invalid char to trigger error from u8::try_from
-        let u5 = u8::try_from(CHARS_INV[ascii]).map_err(|_| Invalid(c))?;
+        let u5 = u8::try_from(CHARS_INV[ascii]).map_err(|_| FromCharError::Invalid(c))?;
 
         Ok(Self(u5))
     }
@@ -325,11 +323,9 @@ pub enum FromCharError {
 
 impl fmt::Display for FromCharError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use FromCharError::*;
-
         match *self {
-            NotAscii(c) => write!(f, "non-ascii char in field element: {}", c),
-            Invalid(c) => write!(f, "invalid char in field element: {}", c),
+            Self::NotAscii(c) => write!(f, "non-ascii char in field element: {}", c),
+            Self::Invalid(c) => write!(f, "invalid char in field element: {}", c),
         }
     }
 }
@@ -337,10 +333,8 @@ impl fmt::Display for FromCharError {
 #[cfg(feature = "std")]
 impl std::error::Error for FromCharError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use FromCharError::*;
-
         match *self {
-            NotAscii(_) | Invalid(_) => None,
+            Self::NotAscii(_) | Self::Invalid(_) => None,
         }
     }
 }
@@ -357,11 +351,9 @@ pub enum TryFromError {
 
 impl fmt::Display for TryFromError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use TryFromError::*;
-
         match *self {
-            NotAByte(ref e) => write_err!(f, "invalid field element"; e),
-            InvalidByte(ref b) => write!(f, "invalid byte in field element: {:#04x}", b),
+            Self::NotAByte(ref e) => write_err!(f, "invalid field element"; e),
+            Self::InvalidByte(ref b) => write!(f, "invalid byte in field element: {:#04x}", b),
         }
     }
 }
@@ -369,11 +361,9 @@ impl fmt::Display for TryFromError {
 #[cfg(feature = "std")]
 impl std::error::Error for TryFromError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use TryFromError::*;
-
         match *self {
-            NotAByte(ref e) => Some(e),
-            InvalidByte(_) => None,
+            Self::NotAByte(ref e) => Some(e),
+            Self::InvalidByte(_) => None,
         }
     }
 }

--- a/src/primitives/gf32.rs
+++ b/src/primitives/gf32.rs
@@ -71,106 +71,106 @@ pub struct Fe32(pub(crate) u8);
 impl Fe32 {
     // These are a little gratuitous for a reference implementation, but it makes me happy to do it.
     /// Numeric value maps to bech32 character: 0 == "q".
-    pub const Q: Fe32 = Fe32(0);
+    pub const Q: Self = Self(0);
     /// Numeric value maps to bech32 character: 1 == "p".
-    pub const P: Fe32 = Fe32(1);
+    pub const P: Self = Self(1);
     /// Numeric value maps to bech32 character: 2 == "z".
-    pub const Z: Fe32 = Fe32(2);
+    pub const Z: Self = Self(2);
     /// Numeric value maps to bech32 character: 3 == "r".
-    pub const R: Fe32 = Fe32(3);
+    pub const R: Self = Self(3);
     /// Numeric value maps to bech32 character: 4 == "y".
-    pub const Y: Fe32 = Fe32(4);
+    pub const Y: Self = Self(4);
     /// Numeric value maps to bech32 character: 5 == "9".
-    pub const _9: Fe32 = Fe32(5);
+    pub const _9: Self = Self(5);
     /// Numeric value maps to bech32 character: 6 == "x".
-    pub const X: Fe32 = Fe32(6);
+    pub const X: Self = Self(6);
     /// Numeric value maps to bech32 character: 7 == "8".
-    pub const _8: Fe32 = Fe32(7);
+    pub const _8: Self = Self(7);
     /// Numeric value maps to bech32 character: 8 == "g".
-    pub const G: Fe32 = Fe32(8);
+    pub const G: Self = Self(8);
     /// Numeric value maps to bech32 character: 9 == "f".
-    pub const F: Fe32 = Fe32(9);
+    pub const F: Self = Self(9);
     /// Numeric value maps to bech32 character: 10 == "2".
-    pub const _2: Fe32 = Fe32(10);
+    pub const _2: Self = Self(10);
     /// Numeric value maps to bech32 character: 11 == "t".
-    pub const T: Fe32 = Fe32(11);
+    pub const T: Self = Self(11);
     /// Numeric value maps to bech32 character: 12 == "v".
-    pub const V: Fe32 = Fe32(12);
+    pub const V: Self = Self(12);
     /// Numeric value maps to bech32 character: 13 == "d".
-    pub const D: Fe32 = Fe32(13);
+    pub const D: Self = Self(13);
     /// Numeric value maps to bech32 character: 14 == "w".
-    pub const W: Fe32 = Fe32(14);
+    pub const W: Self = Self(14);
     /// Numeric value maps to bech32 character: 15 == "0".
-    pub const _0: Fe32 = Fe32(15);
+    pub const _0: Self = Self(15);
     /// Numeric value maps to bech32 character: 16 == "s".
-    pub const S: Fe32 = Fe32(16);
+    pub const S: Self = Self(16);
     /// Numeric value maps to bech32 character: 17 == "3".
-    pub const _3: Fe32 = Fe32(17);
+    pub const _3: Self = Self(17);
     /// Numeric value maps to bech32 character: 18 == "j".
-    pub const J: Fe32 = Fe32(18);
+    pub const J: Self = Self(18);
     /// Numeric value maps to bech32 character: 19 == "n".
-    pub const N: Fe32 = Fe32(19);
+    pub const N: Self = Self(19);
     /// Numeric value maps to bech32 character: 20 == "5".
-    pub const _5: Fe32 = Fe32(20);
+    pub const _5: Self = Self(20);
     /// Numeric value maps to bech32 character: 21 == "4".
-    pub const _4: Fe32 = Fe32(21);
+    pub const _4: Self = Self(21);
     /// Numeric value maps to bech32 character: 22 == "k".
-    pub const K: Fe32 = Fe32(22);
+    pub const K: Self = Self(22);
     /// Numeric value maps to bech32 character: 23 == "h".
-    pub const H: Fe32 = Fe32(23);
+    pub const H: Self = Self(23);
     /// Numeric value maps to bech32 character: 24 == "c".
-    pub const C: Fe32 = Fe32(24);
+    pub const C: Self = Self(24);
     /// Numeric value maps to bech32 character: 25 == "e".
-    pub const E: Fe32 = Fe32(25);
+    pub const E: Self = Self(25);
     /// Numeric value maps to bech32 character: 26 == "6".
-    pub const _6: Fe32 = Fe32(26);
+    pub const _6: Self = Self(26);
     /// Numeric value maps to bech32 character: 27 == "m".
-    pub const M: Fe32 = Fe32(27);
+    pub const M: Self = Self(27);
     /// Numeric value maps to bech32 character: 28 == "u".
-    pub const U: Fe32 = Fe32(28);
+    pub const U: Self = Self(28);
     /// Numeric value maps to bech32 character: 29 == "a".
-    pub const A: Fe32 = Fe32(29);
+    pub const A: Self = Self(29);
     /// Numeric value maps to bech32 character: 30 == "7".
-    pub const _7: Fe32 = Fe32(30);
+    pub const _7: Self = Self(30);
     /// Numeric value maps to bech32 character: 31 == "l".
-    pub const L: Fe32 = Fe32(31);
+    pub const L: Self = Self(31);
 
     /// Iterator over all field elements, in alphabetical order.
     #[inline]
-    pub fn iter_alpha() -> impl Iterator<Item = Fe32> {
+    pub fn iter_alpha() -> impl Iterator<Item = Self> {
         [
-            Fe32::A,
-            Fe32::C,
-            Fe32::D,
-            Fe32::E,
-            Fe32::F,
-            Fe32::G,
-            Fe32::H,
-            Fe32::J,
-            Fe32::K,
-            Fe32::L,
-            Fe32::M,
-            Fe32::N,
-            Fe32::P,
-            Fe32::Q,
-            Fe32::R,
-            Fe32::S,
-            Fe32::T,
-            Fe32::U,
-            Fe32::V,
-            Fe32::W,
-            Fe32::X,
-            Fe32::Y,
-            Fe32::Z,
-            Fe32::_0,
-            Fe32::_2,
-            Fe32::_3,
-            Fe32::_4,
-            Fe32::_5,
-            Fe32::_6,
-            Fe32::_7,
-            Fe32::_8,
-            Fe32::_9,
+            Self::A,
+            Self::C,
+            Self::D,
+            Self::E,
+            Self::F,
+            Self::G,
+            Self::H,
+            Self::J,
+            Self::K,
+            Self::L,
+            Self::M,
+            Self::N,
+            Self::P,
+            Self::Q,
+            Self::R,
+            Self::S,
+            Self::T,
+            Self::U,
+            Self::V,
+            Self::W,
+            Self::X,
+            Self::Y,
+            Self::Z,
+            Self::_0,
+            Self::_2,
+            Self::_3,
+            Self::_4,
+            Self::_5,
+            Self::_6,
+            Self::_7,
+            Self::_8,
+            Self::_9,
         ]
         .iter()
         .copied()
@@ -182,7 +182,7 @@ impl Fe32 {
     ///
     /// If the input char is not part of the bech32 alphabet.
     #[inline]
-    pub fn from_char(c: char) -> Result<Fe32, FromCharError> {
+    pub fn from_char(c: char) -> Result<Self, FromCharError> {
         use FromCharError::*;
 
         // i8::try_from gets a value in the range 0..=127 since char is unsigned.
@@ -192,7 +192,7 @@ impl Fe32 {
         // We use -1 for any array element that is an invalid char to trigger error from u8::try_from
         let u5 = u8::try_from(CHARS_INV[ascii]).map_err(|_| Invalid(c))?;
 
-        Ok(Fe32(u5))
+        Ok(Self(u5))
     }
 
     /// Creates a field element from a single bech32 character.
@@ -200,7 +200,7 @@ impl Fe32 {
     /// # Panics
     ///
     /// If the input character is not part of the bech32 alphabet.
-    pub fn from_char_unchecked(c: u8) -> Fe32 { Fe32(CHARS_INV[usize::from(c)] as u8) }
+    pub fn from_char_unchecked(c: u8) -> Self { Self(CHARS_INV[usize::from(c)] as u8) }
 
     /// Converts the field element to a lowercase bech32 character.
     #[inline]
@@ -221,7 +221,7 @@ impl fmt::Display for Fe32 {
 
 impl From<Fe32> for u8 {
     #[inline]
-    fn from(v: Fe32) -> u8 { v.0 }
+    fn from(v: Fe32) -> Self { v.0 }
 }
 
 macro_rules! impl_try_from {
@@ -255,29 +255,29 @@ impl AsRef<u8> for Fe32 {
 }
 
 impl Bech32Field for Fe32 {
-    fn _add(&self, other: &Fe32) -> Fe32 { Fe32(self.0 ^ other.0) }
+    fn _add(&self, other: &Self) -> Self { Self(self.0 ^ other.0) }
 
-    fn _mul(&self, other: &Fe32) -> Fe32 {
+    fn _mul(&self, other: &Self) -> Self {
         if self.0 == 0 || other.0 == 0 {
-            Fe32(0)
+            Self(0)
         } else {
             let log1 = LOG[usize::from(self.0)];
             let log2 = LOG[usize::from(other.0)];
             let mult_order = Self::MULTIPLICATIVE_ORDER as isize;
-            Fe32(LOG_INV[((log1 + log2) % mult_order) as usize])
+            Self(LOG_INV[((log1 + log2) % mult_order) as usize])
         }
     }
 
-    fn _div(&self, other: &Fe32) -> Fe32 {
+    fn _div(&self, other: &Self) -> Self {
         if self.0 == 0 {
-            Fe32(0)
+            Self(0)
         } else if other.0 == 0 {
             panic!("Attempt to divide {} by 0 in GF32", self);
         } else {
             let log1 = LOG[usize::from(self.0)];
             let log2 = LOG[usize::from(other.0)];
             let mult_order = Self::MULTIPLICATIVE_ORDER as isize;
-            Fe32(LOG_INV[((mult_order + log1 - log2) % mult_order) as usize])
+            Self(LOG_INV[((mult_order + log1 - log2) % mult_order) as usize])
         }
     }
 
@@ -294,9 +294,9 @@ impl Bech32Field for Fe32 {
 }
 
 impl Field for Fe32 {
-    const ZERO: Self = Fe32::Q;
-    const ONE: Self = Fe32::P;
-    const GENERATOR: Self = Fe32::Z;
+    const ZERO: Self = Self::Q;
+    const ONE: Self = Self::P;
+    const GENERATOR: Self = Self::Z;
     const CHARACTERISTIC: usize = 2;
     const MULTIPLICATIVE_ORDER: usize = 31;
     const MULTIPLICATIVE_ORDER_FACTORS: &'static [usize] = &[1, 31];
@@ -309,8 +309,8 @@ super::impl_ops_for_fe!(impl for Fe32);
 impl super::ExtensionField for Fe32 {
     type BaseField = Self;
     const DEGREE: usize = 1;
-    const POLYNOMIAL: Self = Fe32::Q;
-    const EXT_ELEM: Self = Fe32::P;
+    const POLYNOMIAL: Self = Self::Q;
+    const EXT_ELEM: Self = Self::P;
 }
 
 /// A galois field error when converting from a character.

--- a/src/primitives/gf32_ext.rs
+++ b/src/primitives/gf32_ext.rs
@@ -26,7 +26,7 @@ pub struct Fe32Ext<const DEG: usize> {
 
 // For some reason this cannot be derived.
 impl<const DEG: usize> Default for Fe32Ext<DEG> {
-    fn default() -> Self { Fe32Ext { inner: [Fe32::Q; DEG] } }
+    fn default() -> Self { Self { inner: [Fe32::Q; DEG] } }
 }
 
 impl<const DEG: usize> From<Fe32> for Fe32Ext<DEG> {
@@ -42,7 +42,7 @@ impl<const DEG: usize> core::convert::TryFrom<Fe32Ext<DEG>> for Fe32 {
 
     fn try_from(ext: Fe32Ext<DEG>) -> Result<Self, Self::Error> {
         for elem in &ext.inner[1..] {
-            if *elem != Fe32::Q {
+            if *elem != Self::Q {
                 return Err(());
             }
         }
@@ -64,7 +64,7 @@ impl<const DEG: usize> fmt::Display for Fe32Ext<DEG> {
 }
 
 impl<const DEG: usize> ops::Mul<&Fe32> for Fe32Ext<DEG> {
-    type Output = Fe32Ext<DEG>;
+    type Output = Self;
     fn mul(mut self, other: &Fe32) -> Self::Output {
         for elem in &mut self.inner {
             *elem *= other;
@@ -74,7 +74,7 @@ impl<const DEG: usize> ops::Mul<&Fe32> for Fe32Ext<DEG> {
 }
 
 impl<const DEG: usize> ops::Mul<Fe32> for Fe32Ext<DEG> {
-    type Output = Fe32Ext<DEG>;
+    type Output = Self;
     fn mul(self, other: Fe32) -> Self::Output { self.mul(&other) }
 }
 

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -85,7 +85,7 @@ impl Hrp {
             return Err(TooLong(hrp.len()));
         }
 
-        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
+        let mut new = Self { buf: [0_u8; MAX_HRP_LEN], size: 0 };
 
         let mut has_lower: bool = false;
         let mut has_upper: bool = false;
@@ -204,7 +204,7 @@ impl Hrp {
     /// Does not check that `hrp` is valid according to BIP-173 but does check for valid ASCII
     /// values, replacing any invalid characters with `X`.
     pub const fn parse_unchecked(hrp: &str) -> Self {
-        let mut new = Hrp { buf: [0_u8; MAX_HRP_LEN], size: 0 };
+        let mut new = Self { buf: [0_u8; MAX_HRP_LEN], size: 0 };
         let hrp_bytes = hrp.as_bytes();
 
         let mut i = 0;

--- a/src/primitives/hrp.rs
+++ b/src/primitives/hrp.rs
@@ -76,13 +76,11 @@ impl Hrp {
     ///
     /// [BIP-173]: <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki>
     pub fn parse(hrp: &str) -> Result<Self, Error> {
-        use Error::*;
-
         if hrp.is_empty() {
-            return Err(Empty);
+            return Err(Error::Empty);
         }
         if hrp.len() > MAX_HRP_LEN {
-            return Err(TooLong(hrp.len()));
+            return Err(Error::TooLong(hrp.len()));
         }
 
         let mut new = Self { buf: [0_u8; MAX_HRP_LEN], size: 0 };
@@ -91,23 +89,23 @@ impl Hrp {
         let mut has_upper: bool = false;
         for (i, c) in hrp.chars().enumerate() {
             if !c.is_ascii() {
-                return Err(NonAsciiChar(c));
+                return Err(Error::NonAsciiChar(c));
             }
             let b = c as u8; // cast OK as we just checked that c is an ASCII value
 
             // Valid subset of ASCII
             if !(33..=126).contains(&b) {
-                return Err(InvalidAsciiByte(b));
+                return Err(Error::InvalidAsciiByte(b));
             }
 
             if b.is_ascii_lowercase() {
                 if has_upper {
-                    return Err(MixedCase);
+                    return Err(Error::MixedCase);
                 }
                 has_lower = true;
             } else if b.is_ascii_uppercase() {
                 if has_lower {
-                    return Err(MixedCase);
+                    return Err(Error::MixedCase);
                 }
                 has_upper = true;
             };
@@ -125,8 +123,6 @@ impl Hrp {
     /// This method is semantically equivalent to `Hrp::parse(&data.to_string())` but avoids
     /// allocating an intermediate string.
     pub fn parse_display<T: core::fmt::Display>(data: T) -> Result<Self, Error> {
-        use Error::*;
-
         struct ByteFormatter {
             arr: [u8; MAX_HRP_LEN],
             index: usize,
@@ -146,19 +142,19 @@ impl Hrp {
                         self.error = Some(Error::NonAsciiChar(ch));
                         break;
                     } else if !(33..=126).contains(&b) {
-                        self.error = Some(InvalidAsciiByte(b));
+                        self.error = Some(Error::InvalidAsciiByte(b));
                         break;
                     }
 
                     if ch.is_ascii_lowercase() {
                         if self.has_upper {
-                            self.error = Some(MixedCase);
+                            self.error = Some(Error::MixedCase);
                             break;
                         }
                         self.has_lower = true;
                     } else if ch.is_ascii_uppercase() {
                         if self.has_lower {
-                            self.error = Some(MixedCase);
+                            self.error = Some(Error::MixedCase);
                             break;
                         }
                         self.has_upper = true;
@@ -191,7 +187,7 @@ impl Hrp {
 
         write!(byte_formatter, "{}", data).expect("custom Formatter cannot fail");
         if byte_formatter.index == 0 {
-            Err(Empty)
+            Err(Error::Empty)
         } else if let Some(err) = byte_formatter.error {
             Err(err)
         } else {
@@ -470,15 +466,14 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-
         match *self {
-            TooLong(len) =>
-                write!(f, "hrp is too long, found {} characters, must be <= {}", len, MAX_HRP_LEN),
-            Empty => write!(f, "hrp is empty, must have at least 1 character"),
-            NonAsciiChar(c) => write!(f, "found non-ASCII character: {}", c),
-            InvalidAsciiByte(b) => write!(f, "byte value is not valid US-ASCII: \'{:x}\'", b),
-            MixedCase => write!(f, "hrp cannot mix upper and lower case"),
+            Self::TooLong(len) => {
+                write!(f, "hrp is too long, found {} characters, must be <= {}", len, MAX_HRP_LEN)
+            }
+            Self::Empty => write!(f, "hrp is empty, must have at least 1 character"),
+            Self::NonAsciiChar(c) => write!(f, "found non-ASCII character: {}", c),
+            Self::InvalidAsciiByte(b) => write!(f, "byte value is not valid US-ASCII: \'{:x}\'", b),
+            Self::MixedCase => write!(f, "hrp cannot mix upper and lower case"),
         }
     }
 }
@@ -486,10 +481,12 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use Error::*;
-
         match *self {
-            TooLong(_) | Empty | NonAsciiChar(_) | InvalidAsciiByte(_) | MixedCase => None,
+            Self::TooLong(_)
+            | Self::Empty
+            | Self::NonAsciiChar(_)
+            | Self::InvalidAsciiByte(_)
+            | Self::MixedCase => None,
         }
     }
 }

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -110,7 +110,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Fe32> {
-        use core::cmp::Ordering::*;
+        use core::cmp::Ordering::{Equal, Greater, Less};
 
         let bit_offset = {
             let ret = self.bit_offset;

--- a/src/primitives/iter.rs
+++ b/src/primitives/iter.rs
@@ -283,8 +283,8 @@ where
     /// Creates a new checksummed iterator which adapts a data iterator of field elements by
     /// appending a checksum.
     #[inline]
-    pub fn new(data: I) -> Checksummed<I, Ck> {
-        Checksummed {
+    pub fn new(data: I) -> Self {
+        Self {
             iter: data,
             checksum_remaining: Ck::CHECKSUM_LENGTH,
             checksum_engine: checksum::Engine::new(),
@@ -294,7 +294,7 @@ where
     /// Creates a new checksummed iterator which adapts a data iterator of field elements by
     /// first inputting the [`Hrp`] and then appending a checksum.
     #[inline]
-    pub fn new_hrp(hrp: Hrp, data: I) -> Checksummed<I, Ck> {
+    pub fn new_hrp(hrp: Hrp, data: I) -> Self {
         let mut ret = Self::new(data);
         ret.checksum_engine.input_hrp(hrp);
         ret

--- a/src/primitives/lfsr.rs
+++ b/src/primitives/lfsr.rs
@@ -48,7 +48,7 @@ impl<F: Field> LfsrIter<F> {
     /// # Panics
     ///
     /// Panics if given an empty list of initial contents.
-    pub fn berlekamp_massey(initial_contents: &[F]) -> LfsrIter<F> {
+    pub fn berlekamp_massey(initial_contents: &[F]) -> Self {
         assert_ne!(initial_contents.len(), 0, "cannot create a LFSR with no initial contents");
 
         // Step numbers taken from Massey 1969 "Shift-register synthesis and BCH decoding"
@@ -149,7 +149,7 @@ impl<F: Field> LfsrIter<F> {
 
         // Copy conn.len() (less the monic term) initial elements into the LSFR.
         let contents = initial_contents.iter().take(conn.len() - 1).cloned().collect();
-        LfsrIter { contents, coeffs: conn.into() }
+        Self { contents, coeffs: conn.into() }
     }
 }
 

--- a/src/primitives/polynomial.rs
+++ b/src/primitives/polynomial.rs
@@ -46,7 +46,7 @@ impl<F: Field> Polynomial<F> {
     pub fn with_monic_leading_term(coeffs: &[F]) -> Self {
         let mut inner: FieldVec<_> = coeffs.iter().rev().cloned().collect();
         inner.push(F::ONE);
-        Polynomial { inner }
+        Self { inner }
     }
 
     /// The degree of the polynomial.
@@ -322,7 +322,7 @@ impl<F: Field> iter::FromIterator<F> for Polynomial<F> {
     where
         I: IntoIterator<Item = F>,
     {
-        Polynomial { inner: FieldVec::from_iter(iter) }
+        Self { inner: FieldVec::from_iter(iter) }
     }
 }
 
@@ -330,34 +330,34 @@ impl<F> From<FieldVec<F>> for Polynomial<F> {
     fn from(inner: FieldVec<F>) -> Self { Self { inner } }
 }
 
-impl<F: Field> ops::Add<&Polynomial<F>> for Polynomial<F> {
-    type Output = Polynomial<F>;
+impl<F: Field> ops::Add<&Self> for Polynomial<F> {
+    type Output = Self;
 
-    fn add(mut self, other: &Polynomial<F>) -> Polynomial<F> {
+    fn add(mut self, other: &Self) -> Self {
         self += other;
         self
     }
 }
 
-impl<F: Field> ops::Add<Polynomial<F>> for Polynomial<F> {
-    type Output = Polynomial<F>;
-    fn add(self, other: Polynomial<F>) -> Polynomial<F> { self + &other }
+impl<F: Field> ops::Add<Self> for Polynomial<F> {
+    type Output = Self;
+    fn add(self, other: Self) -> Self { self + &other }
 }
 
-impl<F: Field> ops::Sub<&Polynomial<F>> for Polynomial<F> {
-    type Output = Polynomial<F>;
-    fn sub(mut self, other: &Polynomial<F>) -> Polynomial<F> {
+impl<F: Field> ops::Sub<&Self> for Polynomial<F> {
+    type Output = Self;
+    fn sub(mut self, other: &Self) -> Self {
         self -= other;
         self
     }
 }
 
-impl<F: Field> ops::Sub<Polynomial<F>> for Polynomial<F> {
-    type Output = Polynomial<F>;
-    fn sub(self, other: Polynomial<F>) -> Polynomial<F> { self - &other }
+impl<F: Field> ops::Sub<Self> for Polynomial<F> {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self { self - &other }
 }
 
-impl<F: Field> ops::AddAssign<&Polynomial<F>> for Polynomial<F> {
+impl<F: Field> ops::AddAssign<&Self> for Polynomial<F> {
     fn add_assign(&mut self, other: &Self) {
         self.zero_pad_up_to(other.inner.len());
         for i in 0..other.inner.len() {
@@ -367,11 +367,11 @@ impl<F: Field> ops::AddAssign<&Polynomial<F>> for Polynomial<F> {
 }
 
 impl<F: Field> ops::AddAssign for Polynomial<F> {
-    fn add_assign(&mut self, other: Polynomial<F>) { *self += &other; }
+    fn add_assign(&mut self, other: Self) { *self += &other; }
 }
 
-impl<F: Field> ops::SubAssign<&Polynomial<F>> for Polynomial<F> {
-    fn sub_assign(&mut self, other: &Polynomial<F>) {
+impl<F: Field> ops::SubAssign<&Self> for Polynomial<F> {
+    fn sub_assign(&mut self, other: &Self) {
         self.zero_pad_up_to(other.inner.len());
         for i in 0..other.inner.len() {
             self.inner[i] -= &other.inner[i];
@@ -380,7 +380,7 @@ impl<F: Field> ops::SubAssign<&Polynomial<F>> for Polynomial<F> {
 }
 
 impl<F: Field> ops::SubAssign for Polynomial<F> {
-    fn sub_assign(&mut self, other: Polynomial<F>) { *self -= &other; }
+    fn sub_assign(&mut self, other: Self) { *self -= &other; }
 }
 
 /// An iterator over the roots of a polynomial.

--- a/src/primitives/segwit.rs
+++ b/src/primitives/segwit.rs
@@ -46,16 +46,14 @@ pub fn validate_witness_program_length(
     length: usize,
     version: Fe32,
 ) -> Result<(), WitnessLengthError> {
-    use WitnessLengthError::*;
-
     if length < 2 {
-        return Err(TooShort);
+        return Err(WitnessLengthError::TooShort);
     }
     if length > 40 {
-        return Err(TooLong);
+        return Err(WitnessLengthError::TooLong);
     }
     if version == VERSION_0 && length != 20 && length != 32 {
-        return Err(InvalidSegwitV0);
+        return Err(WitnessLengthError::InvalidSegwitV0);
     }
     Ok(())
 }
@@ -91,12 +89,10 @@ pub enum WitnessLengthError {
 
 impl fmt::Display for WitnessLengthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use WitnessLengthError::*;
-
         match *self {
-            TooShort => write!(f, "witness program is less than 2 bytes long"),
-            TooLong => write!(f, "witness program is more than 40 bytes long"),
-            InvalidSegwitV0 => write!(f, "the segwit v0 witness is not 20 or 32 bytes long"),
+            Self::TooShort => write!(f, "witness program is less than 2 bytes long"),
+            Self::TooLong => write!(f, "witness program is more than 40 bytes long"),
+            Self::InvalidSegwitV0 => write!(f, "the segwit v0 witness is not 20 or 32 bytes long"),
         }
     }
 }
@@ -104,10 +100,8 @@ impl fmt::Display for WitnessLengthError {
 #[cfg(feature = "std")]
 impl std::error::Error for WitnessLengthError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use WitnessLengthError::*;
-
         match *self {
-            TooShort | TooLong | InvalidSegwitV0 => None,
+            Self::TooShort | Self::TooLong | Self::InvalidSegwitV0 => None,
         }
     }
 }

--- a/src/segwit.rs
+++ b/src/segwit.rs
@@ -388,13 +388,11 @@ pub enum EncodeError {
 #[cfg(feature = "alloc")]
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use EncodeError::*;
-
         match *self {
-            WitnessVersion(ref e) => write_err!(f, "witness version"; e),
-            WitnessLength(ref e) => write_err!(f, "witness length"; e),
-            TooLong(ref e) => write_err!(f, "encode error"; e),
-            Fmt(ref e) => write_err!(f, "writing to formatter failed"; e),
+            Self::WitnessVersion(ref e) => write_err!(f, "witness version"; e),
+            Self::WitnessLength(ref e) => write_err!(f, "witness length"; e),
+            Self::TooLong(ref e) => write_err!(f, "encode error"; e),
+            Self::Fmt(ref e) => write_err!(f, "writing to formatter failed"; e),
         }
     }
 }
@@ -403,13 +401,11 @@ impl fmt::Display for EncodeError {
 #[cfg(feature = "alloc")]
 impl std::error::Error for EncodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use EncodeError::*;
-
         match *self {
-            WitnessVersion(ref e) => Some(e),
-            WitnessLength(ref e) => Some(e),
-            TooLong(ref e) => Some(e),
-            Fmt(ref e) => Some(e),
+            Self::WitnessVersion(ref e) => Some(e),
+            Self::WitnessLength(ref e) => Some(e),
+            Self::TooLong(ref e) => Some(e),
+            Self::Fmt(ref e) => Some(e),
         }
     }
 }


### PR DESCRIPTION
- Patch 1 - Cleanup repetition of type name in impl blocks where alias of `Self` is applicable.
- Patch 2 - Remove the use of `glob` for importing enum variants.
- Patch 3 - Destructure value from `Result<T>` using `let-else`.