### PR TITLE
Manual daily update to rustc (to nightly-2026-08-12)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rust-version = "1.56.1"
 
 [package.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-31"
+nightly = "nightly-2026-08-12"
 stable = "stable"
 
 [features]

--- a/src/primitives/decode.rs
+++ b/src/primitives/decode.rs
@@ -1067,7 +1067,7 @@ mod tests {
     fn bip_173_invalid_parsing_fails() {
         use UncheckedHrpstringError::*;
 
-        let invalid: Vec<(&str, UncheckedHrpstringError)> = vec!(
+        let invalid: Vec<(&str, UncheckedHrpstringError)> = vec![
             ("\u{20}1nwldj5",
              // TODO: Rust >= 1.59.0 use Hrp(hrp::Error::InvalidAsciiByte('\u{20}'.try_into().unwrap()))),
              Hrp(hrp::Error::InvalidAsciiByte(32))),
@@ -1091,7 +1091,7 @@ mod tests {
              Hrp(hrp::Error::Empty)),
             ("1qzzfhee",
              Hrp(hrp::Error::Empty)),
-        );
+        ];
 
         for (s, want) in invalid {
             let got = UncheckedHrpstring::new(s).unwrap_err();
@@ -1120,7 +1120,7 @@ mod tests {
     fn bip_350_invalid_parsing_fails() {
         use UncheckedHrpstringError::*;
 
-        let invalid: Vec<(&str, UncheckedHrpstringError)> = vec!(
+        let invalid: Vec<(&str, UncheckedHrpstringError)> = vec![
             ("\u{20}1xj0phk",
              // TODO: Rust >= 1.59.0 use Hrp(hrp::Error::InvalidAsciiByte('\u{20}'.try_into().unwrap()))),
              Hrp(hrp::Error::InvalidAsciiByte(32))),
@@ -1148,8 +1148,7 @@ mod tests {
              Hrp(hrp::Error::Empty)),
             ("1p2gdwpf",
              Hrp(hrp::Error::Empty)),
-
-        );
+        ];
 
         for (s, want) in invalid {
             let got = UncheckedHrpstring::new(s).unwrap_err();


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bech32/pull/294

Fixes a lint error by switching to square bracket. Either this or the bot picks up.
